### PR TITLE
Add application scaffolding

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,0 +1,4 @@
+OPENAI_API_KEY=your-openai-key
+TRELLO_API_KEY=your-trello-key
+TRELLO_TOKEN=your-trello-token
+TRELLO_BOARD_ID=your-board-id

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+__pycache__/
+.env
+*.pyc
+*.pyo
+*.pyd
+.vscode/
+.idea/
+.DS_Store

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM python:3.10-slim
+WORKDIR /app
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+COPY . .
+EXPOSE 8501
+CMD ["streamlit", "run", "streamlit_app.py", "--server.port", "8501", "--server.address", "0.0.0.0"]

--- a/README.md
+++ b/README.md
@@ -1,1 +1,41 @@
 # ai-agent-trello
+
+## Goal
+Build a local-first AI assistant that reads meeting transcripts, extracts tasks
+using an LLM, classifies them by project using FAISS, compares them to existing
+Trello cards, and provides a Streamlit interface to review and sync updates.
+
+## Key Features
+1. **Upload Transcript**: Drag-and-drop transcripts in Streamlit.
+2. **LLM Task Extraction**: Use OpenAI GPT to extract structured task data.
+3. **Project Classification**: Match tasks to the correct Trello project using a
+   local FAISS vector store.
+4. **Trello Sync**: Compare extracted tasks to existing cards and create or update as needed.
+5. **Confirmation Step**: Review proposed changes before syncing.
+
+## Tech Stack
+- Python 3.10+
+- LangChain
+- OpenAI API
+- FAISS (local vectorstore)
+- Trello API
+- Streamlit
+- Docker & dotenv
+
+## Setup
+1. Install dependencies:
+   ```bash
+   pip install -r requirements.txt
+   ```
+2. Copy `.env.sample` to `.env` and fill in your API keys.
+3. Run the Streamlit app:
+   ```bash
+   streamlit run streamlit_app.py
+   ```
+
+You can also build and run with Docker:
+
+```bash
+docker build -t ai-trello-agent .
+docker run --env-file .env -p 8501:8501 ai-trello-agent
+```

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,6 @@
+langchain>=0.1.0
+openai>=1.0.0
+faiss-cpu
+streamlit
+python-dotenv
+requests

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -1,0 +1,40 @@
+import os
+from typing import List, Dict
+
+import streamlit as st
+from dotenv import load_dotenv
+
+from trello_agent.task_extraction import extract_tasks
+from trello_agent.classifier import ProjectClassifier
+from trello_agent.trello_client import create_card, get_cards
+
+
+def load_env() -> None:
+    if os.path.exists('.env'):
+        load_dotenv('.env')
+
+
+def main() -> None:
+    load_env()
+    st.title('AI Trello Agent')
+    transcript_file = st.file_uploader('Upload transcript', type=['txt'])
+    if transcript_file:
+        transcript = transcript_file.read().decode('utf-8')
+        tasks = extract_tasks(transcript, os.environ['OPENAI_API_KEY'])
+        if tasks:
+            st.subheader('Extracted Tasks')
+            for i, task in enumerate(tasks, 1):
+                st.text(f"{i}. {task['description']}")
+        else:
+            st.write('No tasks found')
+
+        if st.button('Sync to Trello'):
+            board_id = os.environ.get('TRELLO_BOARD_ID')
+            cards = get_cards(board_id)
+            for task in tasks:
+                create_card(board_id, task['description'], '')
+            st.success('Synced to Trello!')
+
+
+if __name__ == '__main__':
+    main()

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -1,0 +1,16 @@
+import importlib
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+MODULES = [
+    'trello_agent.task_extraction',
+    'trello_agent.classifier',
+    'trello_agent.trello_client',
+]
+
+
+def test_imports():
+    for mod in MODULES:
+        importlib.import_module(mod)

--- a/trello_agent/__init__.py
+++ b/trello_agent/__init__.py
@@ -1,0 +1,1 @@
+__all__ = ['task_extraction', 'classifier', 'trello_client']

--- a/trello_agent/classifier.py
+++ b/trello_agent/classifier.py
@@ -1,0 +1,17 @@
+from typing import List
+
+from langchain.embeddings import OpenAIEmbeddings
+from langchain.vectorstores import FAISS
+
+
+class ProjectClassifier:
+    """Classify tasks into projects using FAISS."""
+
+    def __init__(self, project_texts: List[str], openai_api_key: str):
+        embeddings = OpenAIEmbeddings(openai_api_key=openai_api_key)
+        self.vstore = FAISS.from_texts(project_texts, embeddings)
+        self.projects = project_texts
+
+    def classify(self, text: str) -> str:
+        doc = self.vstore.similarity_search(text, k=1)[0]
+        return doc.page_content

--- a/trello_agent/main.py
+++ b/trello_agent/main.py
@@ -1,0 +1,34 @@
+import os
+from typing import List, Dict
+
+from dotenv import load_dotenv
+
+from .task_extraction import extract_tasks
+from .classifier import ProjectClassifier
+from .trello_client import create_card, get_cards
+
+
+def load_env() -> None:
+    if os.path.exists('.env'):
+        load_dotenv('.env')
+
+
+def process_transcript(transcript: str) -> List[Dict[str, str]]:
+    openai_key = os.environ['OPENAI_API_KEY']
+    tasks = extract_tasks(transcript, openai_key)
+    return tasks
+
+
+if __name__ == '__main__':
+    import sys
+
+    load_env()
+    if len(sys.argv) < 2:
+        print('Usage: python -m trello_agent.main <transcript.txt>')
+        raise SystemExit(1)
+
+    with open(sys.argv[1], 'r') as f:
+        transcript = f.read()
+
+    tasks = process_transcript(transcript)
+    print(tasks)

--- a/trello_agent/task_extraction.py
+++ b/trello_agent/task_extraction.py
@@ -1,0 +1,27 @@
+import json
+from typing import List, Dict
+
+from langchain.chat_models import ChatOpenAI
+from langchain.prompts import ChatPromptTemplate
+from langchain.schema import HumanMessage
+
+
+PROMPT_TEMPLATE = (
+    "You will be given a meeting transcript. "
+    "Extract all actionable tasks and output them as a JSON array. "
+    "Each task should have a 'description' field."
+)
+
+
+def extract_tasks(transcript: str, openai_api_key: str) -> List[Dict[str, str]]:
+    """Use an LLM to extract tasks from a transcript."""
+    chat = ChatOpenAI(openai_api_key=openai_api_key, temperature=0)
+    prompt = ChatPromptTemplate.from_template(PROMPT_TEMPLATE)
+    message = HumanMessage(content=prompt.format())
+    response = chat([message, HumanMessage(content=transcript)])
+    try:
+        tasks = json.loads(response.content)
+        assert isinstance(tasks, list)
+    except Exception:
+        tasks = []
+    return tasks

--- a/trello_agent/trello_client.py
+++ b/trello_agent/trello_client.py
@@ -1,0 +1,36 @@
+import os
+from typing import Any, Dict, List
+
+import requests
+
+BASE_URL = "https://api.trello.com/1"
+
+
+def _auth_params() -> Dict[str, str]:
+    return {
+        "key": os.environ["TRELLO_API_KEY"],
+        "token": os.environ["TRELLO_TOKEN"],
+    }
+
+
+def get_cards(board_id: str) -> List[Dict[str, Any]]:
+    url = f"{BASE_URL}/boards/{board_id}/cards"
+    r = requests.get(url, params=_auth_params())
+    r.raise_for_status()
+    return r.json()
+
+
+def create_card(list_id: str, name: str, desc: str) -> Dict[str, Any]:
+    url = f"{BASE_URL}/cards"
+    params = {"idList": list_id, "name": name, "desc": desc, **_auth_params()}
+    r = requests.post(url, params=params)
+    r.raise_for_status()
+    return r.json()
+
+
+def update_card(card_id: str, name: str, desc: str) -> Dict[str, Any]:
+    url = f"{BASE_URL}/cards/{card_id}"
+    params = {"name": name, "desc": desc, **_auth_params()}
+    r = requests.put(url, params=params)
+    r.raise_for_status()
+    return r.json()


### PR DESCRIPTION
## Summary
- add initial Python modules for task extraction, project classification, Trello sync
- include Streamlit interface and Dockerfile
- add requirements and environment sample
- update README with setup instructions

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'langchain')*

------
https://chatgpt.com/codex/tasks/task_e_686382a30d90832d840450a3d699b661