### PR TITLE
Add Streamlit chat and Trello helper functions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ __pycache__/
 .DS_Store
 /venv/
 /vevn/
+/transcripts/

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -24,7 +24,7 @@ def handle_user_message(message: str) -> str:
     if message.lower().startswith('review trello') or 'duplicate' in message.lower():
         dups = find_duplicates(board_id, st.session_state.get('tasks', []))
         if dups:
-            return 'Duplicates:\n' + '\n'.join(f'- {d}' for d in dups)
+            return 'This are the Duplicates:\n' + '\n'.join(f'- {d}' for d in dups)
         return 'No duplicates found.'
     if message.lower().startswith('sync') or 'upload' in message.lower():
         sync_tasks(board_id, st.session_state.get('tasks', []))

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -1,12 +1,16 @@
 import os
-from typing import List, Dict
 
 import streamlit as st
 from dotenv import load_dotenv
 
+from langchain.schema import AIMessage, HumanMessage, SystemMessage
+from langchain_openai import ChatOpenAI
+
 from trello_agent.task_extraction import extract_tasks
-from trello_agent.classifier import ProjectClassifier
-from trello_agent.trello_client import create_card, get_cards
+from trello_agent.trello_client import (
+    find_duplicates,
+    sync_tasks,
+)
 
 
 def load_env() -> None:
@@ -14,26 +18,62 @@ def load_env() -> None:
         load_dotenv('.env')
 
 
+def handle_user_message(message: str) -> str:
+    """Respond to user queries and optionally interact with Trello."""
+    board_id = os.environ.get('TRELLO_BOARD_ID')
+    if message.lower().startswith('review trello') or 'duplicate' in message.lower():
+        dups = find_duplicates(board_id, st.session_state.get('tasks', []))
+        if dups:
+            return 'Duplicates:\n' + '\n'.join(f'- {d}' for d in dups)
+        return 'No duplicates found.'
+    if message.lower().startswith('sync') or 'upload' in message.lower():
+        sync_tasks(board_id, st.session_state.get('tasks', []))
+        return 'Synced tasks to Trello.'
+
+    chat = ChatOpenAI(openai_api_key=os.environ['OPENAI_API_KEY'], temperature=0)
+    history = [
+        HumanMessage(m['content']) if m['role'] == 'user' else AIMessage(m['content'])
+        for m in st.session_state.get('messages', [])
+    ]
+    history.append(HumanMessage(message))
+    resp = chat.invoke([SystemMessage('You are a helpful assistant for task management.')]+history)
+    return resp.content
+
+
 def main() -> None:
     load_env()
     st.title('AI Trello Agent')
+
+    if 'messages' not in st.session_state:
+        st.session_state.messages = []
+    if 'tasks' not in st.session_state:
+        st.session_state.tasks = []
+
     transcript_file = st.file_uploader('Upload transcript', type=['txt'])
     if transcript_file:
         transcript = transcript_file.read().decode('utf-8')
-        tasks = extract_tasks(transcript, os.environ['OPENAI_API_KEY'])
-        if tasks:
+        st.session_state.tasks = extract_tasks(transcript, os.environ['OPENAI_API_KEY'])
+        if st.session_state.tasks:
             st.subheader('Extracted Tasks')
-            for i, task in enumerate(tasks, 1):
+            for i, task in enumerate(st.session_state.tasks, 1):
                 st.text(f"{i}. {task['description']}")
         else:
             st.write('No tasks found')
 
         if st.button('Sync to Trello'):
             board_id = os.environ.get('TRELLO_BOARD_ID')
-            cards = get_cards(board_id)
-            for task in tasks:
-                create_card(board_id, task['description'], '')
+            sync_tasks(board_id, st.session_state.tasks)
             st.success('Synced to Trello!')
+
+    for msg in st.session_state.messages:
+        st.chat_message(msg['role']).write(msg['content'])
+
+    prompt = st.chat_input('Ask a question')
+    if prompt:
+        st.session_state.messages.append({'role': 'user', 'content': prompt})
+        response = handle_user_message(prompt)
+        st.session_state.messages.append({'role': 'assistant', 'content': response})
+        st.chat_message('assistant').write(response)
 
 
 if __name__ == '__main__':

--- a/transcripts/transcrip01.txt
+++ b/transcripts/transcrip01.txt
@@ -1,1 +1,1 @@
-Hello, for the panam project I need to fix the button to update the charts, and also i need to create a new window to add explore the data. For the current charts, can you change the color of the lines and so on
+Hello, for the panam project I need to fix the button to update the charts, and also i need to create a new window to add explore the data. For the current charts, can you change the color of the lines and so onWe need to plan a Meeting with the Okavango team, we also need to plan the goals for the next quarter

--- a/trello_agent/main.py
+++ b/trello_agent/main.py
@@ -34,3 +34,7 @@ if __name__ == '__main__':
 
     tasks = process_transcript(transcript)
     print(tasks)
+
+    get_cards
+
+

--- a/trello_agent/trello_client.py
+++ b/trello_agent/trello_client.py
@@ -24,6 +24,9 @@ def create_card(list_id: str, name: str, desc: str) -> Dict[str, Any]:
     url = f"{BASE_URL}/cards"
     params = {"idList": list_id, "name": name, "desc": desc, **_auth_params()}
     r = requests.post(url, params=params)
+    print("🔁 Request URL:", r.url)
+    print("📤 Sent data:", params)
+    print("📥 Response:", r.text)
     r.raise_for_status()
     return r.json()
 
@@ -47,4 +50,5 @@ def sync_tasks(board_id: str, tasks: List[Dict[str, str]]) -> None:
     existing = {card["name"] for card in get_cards(board_id)}
     for task in tasks:
         if task["description"] not in existing:
-            create_card(board_id, task["description"], task.get("desc", ""))
+            create_card("68639768a27aad70ea067748", task["description"], task.get("desc", ""))
+

--- a/trello_agent/trello_client.py
+++ b/trello_agent/trello_client.py
@@ -34,3 +34,17 @@ def update_card(card_id: str, name: str, desc: str) -> Dict[str, Any]:
     r = requests.put(url, params=params)
     r.raise_for_status()
     return r.json()
+
+
+def find_duplicates(board_id: str, tasks: List[Dict[str, str]]) -> List[str]:
+    """Return task descriptions that already exist as card names."""
+    existing = {card["name"] for card in get_cards(board_id)}
+    return [t["description"] for t in tasks if t["description"] in existing]
+
+
+def sync_tasks(board_id: str, tasks: List[Dict[str, str]]) -> None:
+    """Create cards for tasks that don't already exist."""
+    existing = {card["name"] for card in get_cards(board_id)}
+    for task in tasks:
+        if task["description"] not in existing:
+            create_card(board_id, task["description"], task.get("desc", ""))


### PR DESCRIPTION
## Summary
- build a chat-style Streamlit UI with conversation history
- add helper functions to check duplicates and sync tasks to Trello

## Testing
- `python -m py_compile streamlit_app.py trello_agent/trello_client.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'langchain_openai')*

------
https://chatgpt.com/codex/tasks/task_e_686394f90340832d80c9419e77d708c4